### PR TITLE
Add study and quiz modes for biology tutor

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -10,7 +10,40 @@ export async function POST(req: Request) {
   const result = await streamText({
     model: openai("gpt-4-turbo"),
     system:
-      "You are a helpful assistant created by Neon.tech and Aceternity. Your job is to answer questions asked by the user in a polite and respectful manner. Always answer in markdown.",
+      `ROLE: Mississippi Biology Tutor (Grades 9-10; MAAP 2018)
+
+SCOPE
+- Use **only** the biology content provided from the database query results.
+- If no relevant content is returned, reply: "I don't know."
+
+WORKFLOW
+When the user types a topic or standard:
+
+1. The app searches the Neon database for the most relevant content.
+2. The matched text is passed to the tutor.
+3. Strip formatting to plain text.
+4. Chunk by substandard (<=600 tokens per chunk).
+
+MODES
+
+Study mode (default) ->
+- Present the first chunk.
+- End with a comprehension-check question.
+- Wait for the user's reply before sending the next chunk.
+- At the end, include a concise summary box of the key points.
+
+Quiz me ->
+- Generate one multiple-choice question from the next chunk.
+- After the user answers, reveal correct/incorrect with a one-sentence rationale.
+- Continue until all chunk questions are complete.
+- At the end of the quiz, report:
+1. Total questions
+2. Correct answers
+3. Percentage score
+4. Letter grade (A-F scale)
+5. List of missed questions with correct answers and brief explanations
+
+Switch modes when the user types "quiz me" or "study mode".`,
     messages,
     onFinish: async (completion) => {
       try {

--- a/components/bubble.tsx
+++ b/components/bubble.tsx
@@ -2,13 +2,11 @@
 import {
   IconArrowNarrowDown,
   IconArrowNarrowUp,
-  IconAssembly,
-  IconBrandMessenger,
+  IconBook,
+  IconQuestionMark,
   IconMessage,
   IconPlayerStopFilled,
   IconPlus,
-  IconSeo,
-  IconTerminal2,
   IconX,
   IconMaximize,
 } from "@tabler/icons-react";
@@ -56,24 +54,14 @@ export const Bubble = () => {
 
   const blocks = [
     {
-      icon: <IconSeo className="h-6 w-6 text-purple-500" />,
-      title: "SEO Tips",
-      content: "How can I improve my blog on tech",
+      icon: <IconBook className="h-6 w-6 text-purple-500" />,
+      title: "Study Mode",
+      content: "study mode",
     },
     {
-      icon: <IconTerminal2 className="h-6 w-6 text-indigo-500" />,
-      title: "Code",
-      content: "How to center a div with Tailwind CSS",
-    },
-    {
-      icon: <IconBrandMessenger className="h-6 w-6 text-pink-500" />,
-      title: "Communication",
-      content: "How to improve communication with my team",
-    },
-    {
-      icon: <IconAssembly className="h-6 w-6 text-orange-500" />,
-      title: "Productivity",
-      content: "How to increase productivity in my work while being occupied",
+      icon: <IconQuestionMark className="h-6 w-6 text-green-500" />,
+      title: "Quiz Mode",
+      content: "quiz me",
     },
   ];
 

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -4,7 +4,6 @@ import { AnimatePresence, motion } from "framer-motion";
 import Image from "next/image";
 import { cn } from "@/lib/utils";
 import Balancer from "react-wrap-balancer";
-import Link from "next/link";
 
 export function Hero() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -72,18 +71,16 @@ export function Hero() {
         ease. Built in collaboration with Neon.tech and Aceternity
       </p>
       <div className="mb-10 mt-8 flex w-full flex-col items-center justify-center gap-4 px-8 sm:flex-row md:mb-20">
-        <Link
-          href="#"
-          className="group relative z-20 flex h-10 w-full cursor-pointer items-center justify-center space-x-2 rounded-lg bg-black p-px px-4 py-2 text-center text-sm font-semibold leading-6 text-white no-underline transition duration-200  sm:w-52"
+        <button
+          className="group relative z-20 flex h-10 w-full cursor-pointer items-center justify-center space-x-2 rounded-lg bg-black p-px px-4 py-2 text-center text-sm font-semibold leading-6 text-white transition duration-200  sm:w-52"
         >
-          Read Documentation
-        </Link>
-        <Link
-          href="/pricing"
-          className="group relative z-20 flex h-10 w-full cursor-pointer items-center justify-center space-x-2 rounded-lg bg-white p-px px-4 py-2 text-sm font-semibold leading-6 text-black no-underline shadow-input transition duration-200 hover:-translate-y-0.5  sm:w-52"
+          Study Mode
+        </button>
+        <button
+          className="group relative z-20 flex h-10 w-full cursor-pointer items-center justify-center space-x-2 rounded-lg bg-white p-px px-4 py-2 text-sm font-semibold leading-6 text-black shadow-input transition duration-200 hover:-translate-y-0.5  sm:w-52"
         >
-          Explore Neon
-        </Link>
+          Quiz Mode
+        </button>
       </div>
       <div
         ref={containerRef}


### PR DESCRIPTION
## Summary
- replace template buttons with Study Mode and Quiz Mode options
- update chat bubble to switch modes via Study or Quiz prompts
- add detailed biology tutor system instructions for LLM

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Failed to load config "next/typescript" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_689770a91048832799b0cee555b760d0