### PR TITLE
Fix env import and annotate hero container ref

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,7 +1,7 @@
 import { openai } from "@ai-sdk/openai";
 import { streamText, embed } from "ai";
 import { neon } from "@neondatabase/serverless";
-import { env } from "@/lib/env";
+import { env } from "../../../lib/env";
 import { toSql } from "pgvector";
 
 export const runtime = "nodejs";

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -10,6 +10,7 @@ interface HeroProps {
 }
 
 export function Hero({ onModeSelect }: HeroProps) {
+  // Reference to the container element for collision animations
   const containerRef = useRef<HTMLDivElement>(null);
   const parentRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
## Summary
- document hero container reference for collision animations
- switch chat API env import to a relative path

## Testing
- `npm install pgvector`
- `npm test >/tmp/test.log && cat /tmp/test.log && echo tests passed`


------
https://chatgpt.com/codex/tasks/task_e_68b4a1fa28a483279051aaea172ffdb2