### PR TITLE
fix: mark home page as client component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Bubble } from "@/components/bubble";
 import { Hero } from "@/components/hero";
 import { useState } from "react";


### PR DESCRIPTION
## Summary
- add missing `"use client"` directive at the top of `app/page.tsx`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a5f4e8288327bdadf4ec475682a6