### PR TITLE
Add cascading standard dropdown selection

### DIFF
--- a/components/bubble.tsx
+++ b/components/bubble.tsx
@@ -20,6 +20,7 @@ import {
 import { useChat } from "ai/react";
 import Markdown from "react-markdown";
 import { cn } from "@/lib/utils";
+import { standards, mainStandardOrder } from "@/lib/standards";
 
 interface BubbleProps {
   mode: "study" | "quiz";
@@ -39,6 +40,8 @@ export const Bubble = ({ mode, onModeChange, seedMessage, onSeeded }: BubbleProp
   const [isUserScrolledUp, setIsUserScrolledUp] = useState(false);
   const messageHistoryRef = useRef<HTMLDivElement>(null);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [mainStandard, setMainStandard] = useState("");
+  const [subStandard, setSubStandard] = useState("");
 
   const {
     messages,
@@ -82,6 +85,27 @@ export const Bubble = ({ mode, onModeChange, seedMessage, onSeeded }: BubbleProp
       content: block.content,
     });
     handleSubmit();
+  };
+
+  const handleMainStandardChange = (
+    e: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    setMainStandard(e.target.value);
+    setSubStandard("");
+  };
+
+  const handleStandardSubmit = () => {
+    if (mainStandard && subStandard) {
+      const option = standards[mainStandard].find(
+        (o) => o.code === subStandard
+      );
+      if (option) {
+        append({ role: "user", content: `${option.code} ${option.label}` });
+        handleSubmit();
+        setMainStandard("");
+        setSubStandard("");
+      }
+    }
   };
 
   useEffect(() => {
@@ -285,6 +309,42 @@ export const Bubble = ({ mode, onModeChange, seedMessage, onSeeded }: BubbleProp
                   ))}
                 </div>
               )}
+              <div className="px-5 pt-2 flex gap-2">
+                <select
+                  value={mainStandard}
+                  onChange={handleMainStandardChange}
+                  className="border p-2 rounded flex-1"
+                >
+                  <option value="">Select standard</option>
+                  {mainStandardOrder.map((key) => (
+                    <option key={key} value={key}>
+                      {key}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={subStandard}
+                  onChange={(e) => setSubStandard(e.target.value)}
+                  disabled={!mainStandard}
+                  className="border p-2 rounded flex-1"
+                >
+                  <option value="">Select topic</option>
+                  {mainStandard &&
+                    standards[mainStandard].map((opt) => (
+                      <option key={opt.code} value={opt.code}>
+                        {opt.label}
+                      </option>
+                    ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={handleStandardSubmit}
+                  disabled={!subStandard}
+                  className="bg-gray-100 px-3 rounded"
+                >
+                  Go
+                </button>
+              </div>
               <div
                 ref={messageHistoryRef}
                 className="p-2 flex flex-1 overflow-y-auto"

--- a/lib/standards.ts
+++ b/lib/standards.ts
@@ -1,0 +1,80 @@
+export interface SubStandard {
+  code: string;
+  label: string;
+}
+
+export const standards: Record<string, SubStandard[]> = {
+  "1A": [
+    { code: "1A0", label: "Scientific Method and the Origin of Life" },
+    { code: "1A1", label: "Characteristics of Life - Living vs Nonliving" },
+    { code: "1A2", label: "The Cell Theory - Hooke, Schleiden, Schwann, Virchow" },
+    { code: "1A3", label: "Cellular Organization - Cell, Tissue, Organ, Organ System" },
+    { code: "1A4", label: "Viruses - Living or Nonliving" }
+  ],
+  "1B": [
+    { code: "1B1", label: "Macromolecules - Carbohydrates, Lipids, Proteins, Nucleic Acids" },
+    { code: "1B2", label: "Enzymes - Catalyst" }
+  ],
+  "1C": [
+    { code: "1C1", label: "Cell Parts - Organelles" },
+    { code: "1C2", label: "Types of Cells - Prokaryotic, Eukaryotic, Plant, Animal, Fungi Cells" },
+    { code: "1C3", label: "Viruses vs Cells - Host Cell Machinery" }
+  ],
+  "1D": [
+    { code: "1D1", label: "Cell Transport - Cell Membrane, Phospholipids, Transport Proteins, Cholesterol" },
+    { code: "1D2", label: "Osmosis and Tonicity - Hypotonic, Hypertonic, Isotonic" }
+  ],
+  "1E": [
+    { code: "1E1", label: "Cell Differentiation and Cancer" },
+    { code: "1E2", label: "The Cell Cycle - Interphase (G1, S, G2), Mitosis, Cytokinesis" },
+    { code: "1E3", label: "Asexual Reproduction - Binary Fission, Budding, Vegetative Propagation, Fragmentation/Regeneration" }
+  ],
+  "2": [
+    { code: "2.1", label: "ATP - Energy in Cells" },
+    { code: "2.2", label: "Photosynthesis - Light-Dependent Reactions, Calvin Cycle, Reactants, Products" },
+    { code: "2.3", label: "Cellular Respiration - Glycolysis, Krebs Cycle, ETC, Reactants, Products" },
+    { code: "2.4", label: "Aerobic and Anaerobic Respiration" }
+  ],
+  "3A": [
+    { code: "3A1", label: "Meiosis and Sexual Reproduction - Spermatogenesis, Oogenesis, Meiosis I & II, Fertilization, Conjugation" },
+    { code: "3A2", label: "Mitosis vs Meiosis" },
+    { code: "3A3", label: "Chromosome Mutations - Nondisjunction; Down, Klinefelter, Turner Syndromes" }
+  ],
+  "3B": [
+    { code: "3B1", label: "Mendel and Punnett Squares" },
+    { code: "3B2", label: "Dihybrid Crosses - 16-square Punnett Squares" },
+    { code: "3B3", label: "Non-Mendelian Genetics - Codominance, Incomplete Dominance, Multiple Alleles (Blood Types), Sex-linked Traits (X-linked)" },
+    { code: "3B4", label: "Human Genetic Disorders and Pedigrees" }
+  ],
+  "3C": [
+    { code: "3C1", label: "DNA, Genes, Chromosomes Relationship" },
+    { code: "3C2", label: "Protein Synthesis - Transcription, Translation, Types of RNA" },
+    { code: "3C3", label: "Gene Mutations - Point & Frameshift (Insertion, Deletion, Substitution)" },
+    { code: "3C4", label: "DNA Technology - Genetic Engineering, Cloning, DNA Fingerprinting, GMOs" }
+  ],
+  "4": [
+    { code: "4.1", label: "Chemical vs Organic Evolution" },
+    { code: "4.2", label: "Evidence of Evolution - Homologous and Analogous Structures" },
+    { code: "4.3", label: "Cladograms and Phylogenetic Trees" },
+    { code: "4.4", label: "Modes of Selection - Stabilizing, Directional, Disruptive" },
+    { code: "4.5", label: "Darwin and Natural Selection" },
+    { code: "4.6", label: "Speciation" }
+  ],
+  "5": [
+    { code: "5.1", label: "Ecological Organization - Organism, Population, Community, Ecosystem" },
+    { code: "5.2", label: "Biogeochemical Cycles - Water, Carbon, Nitrogen, Phosphorus" },
+    { code: "5.3", label: "Greenhouse Gases" },
+    { code: "5.4", label: "Energy and Biomass in Ecosystems - Trophic, Energy, Biomass, Numbers Pyramids" },
+    { code: "5.5", label: "Ecological Relationships - Herbivory, Predation, Mutualism, Commensalism, Parasitism" },
+    { code: "5.6", label: "Populations - Carrying Capacity, Limiting Factors, Exponential and Logistic Growth" },
+    { code: "5.7", label: "Ecological Succession - Primary, Secondary" }
+  ]
+};
+
+export const mainStandardOrder = [
+  "1A", "1B", "1C", "1D", "1E",
+  "2",
+  "3A", "3B", "3C",
+  "4",
+  "5"
+];


### PR DESCRIPTION
## Summary
- add standards map and main standard order for dropdowns
- integrate cascading dropdowns in chat bubble to select and submit standards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b58a35a7f0832784fc001c66c4ea10