### PR TITLE
Handle missing database url env

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -10,7 +10,10 @@ const envSchema = z.object({
 });
 
 export const env = envSchema.parse({
-  DATABASE_URL: process.env.DATABASE_URL,
+  // Some platforms expose empty strings for missing env vars. Convert
+  // falsy values to `undefined` so optional validation passes instead of
+  // throwing an "Invalid url" error during builds.
+  DATABASE_URL: process.env.DATABASE_URL || undefined,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
   OPENAI_ORG: process.env.OPENAI_ORG,
 });


### PR DESCRIPTION
## Summary
- Prevent invalid DATABASE_URL values from causing build-time Zod errors by normalizing falsy env vars to undefined.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b15632d88327b01d42bf0f993f96