### PR TITLE
Integrate polished chatbot with cascading topic dropdown

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,27 +1,5 @@
-"use client";
-
-import { Bubble } from "@/components/bubble";
-import { Hero } from "@/components/hero";
-import { useState } from "react";
+import PolishedBioChatbot from "@/components/polished-bio-chatbot";
 
 export default function Home() {
-  const [mode, setMode] = useState<"study" | "quiz">("study");
-  const [seed, setSeed] = useState<string | null>(null);
-
-  return (
-    <div className="w-full flex items-center justify-center overflow-hidden relative">
-      <Hero
-        onModeSelect={(m) => {
-          setMode(m);
-          setSeed(m === "study" ? "study mode" : "quiz me");
-        }}
-      />
-      <Bubble
-        mode={mode}
-        onModeChange={setMode}
-        seedMessage={seed}
-        onSeeded={() => setSeed(null)}
-      />
-    </div>
-  );
+  return <PolishedBioChatbot />;
 }


### PR DESCRIPTION
## Summary
- Replace landing page with polished chatbot interface
- Provide cascading topic selector backed by standards map

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b6f3fa388327a775b59e6f24ec51