### PR TITLE
fix: mark chatbot component as client

### DIFF
--- a/components/polished-bio-chatbot.tsx
+++ b/components/polished-bio-chatbot.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from 'react';
 import { IconBook, IconHelpCircle, IconSend, IconSettings, IconSparkles } from '@tabler/icons-react';
 import { standards, mainStandards } from '@/lib/standards';


### PR DESCRIPTION
## Summary
- mark polished bio chatbot component as a client component so that useState is allowed

## Testing
- `npm test`
- `npm run lint`
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b856460083278aee4ecc2db94e29