### PR TITLE
Make OPENAI_API_KEY optional and fix React hook / listener warnings

### DIFF
--- a/components/background-grids.tsx
+++ b/components/background-grids.tsx
@@ -180,7 +180,7 @@ const CollisionMechanism = React.forwardRef<
     const animationInterval = setInterval(checkCollision, 50);
 
     return () => clearInterval(animationInterval);
-  }, [cycleCollisionDetected, containerRef]);
+  }, [cycleCollisionDetected, containerRef, parentRef]);
 
   useEffect(() => {
     if (collision.detected && collision.coordinates) {

--- a/components/bubble.tsx
+++ b/components/bubble.tsx
@@ -127,13 +127,11 @@ export const Bubble = ({ mode, onModeChange, seedMessage, onSeeded }: BubbleProp
       }
     };
 
-    messageHistoryRef.current?.addEventListener("scroll", handleUserScroll);
+    const historyElement = messageHistoryRef.current;
+    historyElement?.addEventListener("scroll", handleUserScroll);
 
     return () => {
-      messageHistoryRef.current?.removeEventListener(
-        "scroll",
-        handleUserScroll
-      );
+      historyElement?.removeEventListener("scroll", handleUserScroll);
     };
   }, []);
 

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -194,7 +194,7 @@ const CollisionMechanism = React.forwardRef<
     const animationInterval = setInterval(checkCollision, 50);
 
     return () => clearInterval(animationInterval);
-  }, [cycleCollisionDetected, containerRef]);
+  }, [cycleCollisionDetected, containerRef, parentRef]);
 
   useEffect(() => {
     if (collision.detected && collision.coordinates) {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -5,7 +5,9 @@ const envSchema = z.object({
   // so mark it as optional to avoid validation errors when the variable
   // isn't provided.
   DATABASE_URL: z.string().url().optional(),
-  OPENAI_API_KEY: z.string().min(1),
+  // OPENAI_API_KEY is only required when calling the chat API at runtime.
+  // Keep it optional during build to avoid static build failures.
+  OPENAI_API_KEY: z.string().min(1).optional(),
   OPENAI_ORG: z.string().optional(),
 });
 
@@ -17,4 +19,3 @@ export const env = envSchema.parse({
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
   OPENAI_ORG: process.env.OPENAI_ORG,
 });
-


### PR DESCRIPTION
### Motivation
- Prevent `next build` from failing when `OPENAI_API_KEY` is not present at build time and resolve React lint warnings related to missing hook dependencies and unstable event listener cleanup.

### Description
- Make `OPENAI_API_KEY` optional in the env schema (`lib/env.ts`) so schema parsing does not throw during static builds.
- Add `parentRef` to the dependency arrays in `components/background-grids.tsx` and `components/hero.tsx` to satisfy React Hook dependency checks.
- Stabilize the scroll listener in `components/bubble.tsx` by capturing `messageHistoryRef.current` into a local `historyElement` variable and using it for both `addEventListener` and `removeEventListener`.

### Testing
- Ran `npm test` and the test suite completed successfully.
- Ran `npm run lint` and there are no ESLint warnings after the changes.
- Ran `npm run build` and the Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5884148bc832790be5f163ebdc484)