### PR TITLE
Normalize optional env vars and use createOpenAI to fix /api/chat build crash

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,4 @@
-import { openai } from "@ai-sdk/openai";
+import { createOpenAI } from "@ai-sdk/openai";
 import { streamText, embed } from "ai";
 import { neon } from "@neondatabase/serverless";
 import { env } from "../../../lib/env";
@@ -42,6 +42,11 @@ export async function POST(req: Request) {
   if (!env.OPENAI_API_KEY || !env.DATABASE_URL || !sql) {
     return new Response("Missing environment variables", { status: 400 });
   }
+  const openai = createOpenAI({
+    apiKey: env.OPENAI_API_KEY,
+    baseURL: env.OPENAI_BASE_URL,
+    organization: env.OPENAI_ORG,
+  });
 
   const lastMessage = messages[messages.length - 1];
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,21 +1,46 @@
 import { z } from "zod";
 
+const optionalString = () =>
+  z.preprocess(
+    (value) => {
+      if (typeof value !== "string") return value;
+      const normalized = value.trim();
+      return normalized.length > 0 ? normalized : undefined;
+    },
+    z.string().optional(),
+  );
+
 const envSchema = z.object({
   // DATABASE_URL may be undefined during build time (e.g. on Vercel),
   // so mark it as optional to avoid validation errors when the variable
   // isn't provided.
-  DATABASE_URL: z.string().url().optional(),
+  DATABASE_URL: z.preprocess(
+    (value) => {
+      if (typeof value !== "string") return value;
+      const normalized = value.trim();
+      return normalized.length > 0 ? normalized : undefined;
+    },
+    z.string().url().optional(),
+  ),
   // OPENAI_API_KEY is only required when calling the chat API at runtime.
   // Keep it optional during build to avoid static build failures.
-  OPENAI_API_KEY: z.string().min(1).optional(),
-  OPENAI_ORG: z.string().optional(),
+  OPENAI_API_KEY: optionalString(),
+  OPENAI_ORG: optionalString(),
+  OPENAI_BASE_URL: z.preprocess(
+    (value) => {
+      if (typeof value !== "string") return value;
+      const normalized = value.trim();
+      return normalized.length > 0 ? normalized : undefined;
+    },
+    z.string().url().optional(),
+  ),
 });
 
 export const env = envSchema.parse({
-  // Some platforms expose empty strings for missing env vars. Convert
-  // falsy values to `undefined` so optional validation passes instead of
-  // throwing an "Invalid url" error during builds.
-  DATABASE_URL: process.env.DATABASE_URL || undefined,
+  // Some platforms expose empty strings for missing env vars. Normalize
+  // those to `undefined` so optional validation passes during builds.
+  DATABASE_URL: process.env.DATABASE_URL,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
   OPENAI_ORG: process.env.OPENAI_ORG,
+  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
 });


### PR DESCRIPTION
### Motivation
- Build-time Zod validation was throwing `Invalid url` when optional environment variables contained empty or whitespace values, causing `/api/chat` page data collection to fail.
- The chat handler relied on an imported OpenAI client that assumed environment values at import time, which contributed to build-time failures when env values were missing or malformed.

### Description
- Add a preprocessing wrapper to normalize optional string env values (trim and convert empty/whitespace to `undefined`) before Zod validation in `lib/env.ts`.
- Change `DATABASE_URL` and add `OPENAI_BASE_URL` as optional URL fields that are preprocessed to tolerate empty values, and normalize `OPENAI_API_KEY` and `OPENAI_ORG` with the new helper.
- Update the chat route to use `createOpenAI(...)` from `@ai-sdk/openai` and instantiate the client with `apiKey`, `baseURL`, and `organization` from the validated `env` object instead of relying on implicit import-time env resolution.

### Testing
- Ran `npm run build`, which completed successfully and produced the optimized production build for the app (static pages generated).
- Ran `npm test`, which executed `test/basic.test.ts` and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58b524df08327813d8d7e8f9797c9)